### PR TITLE
failed tests on libgfapi 11

### DIFF
--- a/gfapi/file.go
+++ b/gfapi/file.go
@@ -7,6 +7,7 @@ package gfapi
 // #include <stdlib.h>
 // #include <sys/stat.h>
 import "C"
+
 import (
 	"errors"
 	"io"
@@ -60,9 +61,9 @@ func (f *File) Chown(uid, gid int) error {
 }
 
 func (f *File) Futimens(atime, mtime time.Time) error {
-	var times [2]C.timespec
-	times[1].tv_sec = mtime.Unix()
-	times[1].tv_nsec = mtime.Nanosecond()
+	var times [2]C.struct_timespec
+	times[0] = C.struct_timespec{tv_sec: C.long(atime.Unix()), tv_nsec: C.long(atime.Nanosecond())}
+	times[1] = C.struct_timespec{tv_sec: C.long(mtime.Unix()), tv_nsec: C.long(mtime.Nanosecond())}
 	return f.Fd.Futimens(times)
 }
 

--- a/gfapi/volume.go
+++ b/gfapi/volume.go
@@ -4,7 +4,7 @@ package gfapi
 // for more information please 'api/src/glfs.h' in the glusterfs source.
 
 //go:generate sh -c "go tool cgo -godefs types_unix.go | gofmt > ztypes_${GOOS}_${GOARCH}.go"
-//TODO: Need to run `go generate` on different platforms to generate relevant ztypes file for each
+// TODO: Need to run `go generate` on different platforms to generate relevant ztypes file for each
 // - *BSD
 // - Mac OS X
 
@@ -14,6 +14,7 @@ package gfapi
 // #include <time.h>
 // #include <sys/stat.h>
 import "C"
+
 import (
 	"errors"
 	"fmt"
@@ -172,7 +173,7 @@ func (v *Volume) Chown(name string, uid, gid int) error {
 	cname := C.CString(name)
 	defer C.free(unsafe.Pointer(cname))
 
-	_, err := C.glfs_chmod(v.fs, cname, C.uid_t(uid), C.gid_t(gid))
+	_, err := C.glfs_chown(v.fs, cname, C.uid_t(uid), C.gid_t(gid))
 
 	return err
 }
@@ -184,10 +185,9 @@ func (v *Volume) Chtimes(name string, mtime time.Time) error {
 	cname := C.CString(name)
 	defer C.free(unsafe.Pointer(cname))
 
-	var amtime [2]C.timespec
-	amtime[1].tv_sec = mtime.Unix()
-	amtime[1].tv_nsec = mtime.Nanosecond()
-	_, err := C.glfs_utimens(v.fs, cname, amtime)
+	var amtime [2]C.struct_timespec
+	amtime[1] = C.struct_timespec{tv_sec: C.long(mtime.Unix()), tv_nsec: C.long(mtime.Nanosecond())}
+	_, err := C.glfs_utimens(v.fs, cname, &amtime[0])
 
 	return err
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/juicedata/gogfapi
+module github.com/kmlebedev/gogfapi
 
-go 1.19
+go 1.23


### PR DESCRIPTION
req
```
libgfapi0-11.1-1.el8s.x86_64
libgfapi-devel-11.1-1.el8s.x86_64
libgcc-8.5.0-22.el8.x86_64
gcc-8.5.0-22.el8.x86_64
```

```
go test  -v .
=== RUN   TestInit
--- PASS: TestInit (0.00s)
=== RUN   TestSetLogging
--- PASS: TestSetLogging (0.00s)
=== RUN   TestMount
    gfapi_test.go:45: Failed to mount volume. error: mount failed: no such file or directory
--- FAIL: TestMount (0.01s)
=== RUN   TestMkdirAll
    gfapi_test.go:54: MkdirAll "/tmp/_TestMkdirAll_/dir/./dir2": mkdir /tmp: input/output error
--- FAIL: TestMkdirAll (0.00s)
=== RUN   TestCreate
    gfapi_test.go:104: Failed to create file. Error = create test: input/output error
--- FAIL: TestCreate (0.00s)
=== RUN   TestClose1
--- FAIL: TestClose1 (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x52e08e]

goroutine 22 [running]:
testing.tRunner.func1.2({0x54aea0, 0x875da0})
	/usr/local/go/src/testing/testing.go:1632 +0x230
testing.tRunner.func1()
	/usr/local/go/src/testing/testing.go:1635 +0x35e
panic({0x54aea0?, 0x875da0?})
	/usr/local/go/src/runtime/panic.go:785 +0x132
github.com/kmlebedev/gogfapi/gfapi.(*File).Close(0x884700?)
	/home/whitefox/gogfapi/sources-blExtdgG3C/gfapi/file.go:34 +0xe
github.com/kmlebedev/gogfapi/gfapi.TestClose1(0xc00018e820)
	/home/whitefox/gogfapi/sources-blExtdgG3C/gfapi/gfapi_test.go:110 +0x26
testing.tRunner(0xc00018e820, 0x57b4a8)
	/usr/local/go/src/testing/testing.go:1690 +0xf4
created by testing.(*T).Run in goroutine 1
	/usr/local/go/src/testing/testing.go:1743 +0x390
FAIL	github.com/kmlebedev/gogfapi/gfapi	0.029s
FAIL
```